### PR TITLE
fix(Vercel): remove 'export' from authOptions to avoid vercel deployment error

### DIFF
--- a/src/app/api/auth/[...nextauth]/route.ts
+++ b/src/app/api/auth/[...nextauth]/route.ts
@@ -4,7 +4,7 @@ import { JWT } from "next-auth/jwt";
 import { Session } from "next-auth";
 import { AdapterUser } from "next-auth/adapters";
 
-export const authOptions = {
+const authOptions = {
   providers: [
     CredentialsProvider({
       type: "credentials",


### PR DESCRIPTION
## Describe your changes
- Remove "export" from authOptions


## P/S
- [X] I have performed a self-review of my code
- [ ] If it is a core feature, I have added tests.